### PR TITLE
Improve fabric.mod.json

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.17
-	yarn_mappings=1.17+build.1
-	loader_version=0.11.3
+	minecraft_version=1.17.1
+	yarn_mappings=1.17.1+build.14
+	loader_version=0.11.6
 
 # Mod Properties
 	mod_version = 1.0.8
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = workings
 
 # Dependencies
-	fabric_version=0.34.9+1.17
+	fabric_version=0.37.0+1.17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "workings",
-  "version": "1.0.8",
+  "version": "${version}",
 
   "name": "Workings",
   "description": "Construction themed mod for ModFest 1.17",
@@ -9,7 +9,9 @@
     "Andrew Grant (Andrew6rant)"
   ],
   "contact": {
-    "sources": "https://github.com/Andrew6rant/Workings"
+    "homepage": "https://modrinth.com/mod/workings",
+    "sources": "https://github.com/Andrew6rant/Workings",
+    "issues": "https://github.com/Andrew6rant/Workings/issues"
   },
 
   "license": "LGPL-2.1",
@@ -30,8 +32,5 @@
     "fabric": "*",
     "minecraft": "1.17.x",
     "java": ">=16"
-  },
-  "suggests": {
-    "another-mod": "*"
   }
 }


### PR DESCRIPTION
**Changes in this pull request**
- Updated Gradle and build dependencies
- Made the fabric.mod.json automatically retrieve the mod version on build (To bump versions change the value of mod_version in gradle.properties)
- Added a homepage and issues page to the fabric.mod.json so users can find the mod page and issue tracker using modmenu.
- Removed the `suggests` section of the fabric.mod.json as it is unused.